### PR TITLE
Added dependencies bokeh, plotly, colorcet, k3d.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,9 +13,9 @@ k3d = [
     "vtk",
     "k3d>=2.9.7",
 ]
-qt = ["PyQt5~=5.15.9"]
+qt = ["PyQt5>=5.15.9"]
 myavi = [
-    "PyQt5~=5.15.9",
+    "PyQt5>=5.15.9",
     "vtk",
     "ipyevents",
     "mayavi @ git+https://git@github.com/enthought/mayavi",
@@ -47,13 +47,17 @@ build-backend = "setuptools.build_meta"
 version = "2023.1.0"
 
 dependencies = [
-    "sympy-plot-backends~=2.4",
-    "sympy~=1.12", 
-    "matplotlib==3.6.*", 
+    "sympy-plot-backends>=2.4",
+    "sympy>=1.12", 
+    "matplotlib>=3.6", 
     "jupyter>=1.0.0", 
     "numpy>=1.24",
+    "bokeh",
+    "plotly",
+    "colorcet",
+    "k3d"
 ]
-requires-python = ">=3.8,<3.12"
+requires-python = ">=3.8"
 
 # generic information
 
@@ -76,6 +80,7 @@ classifiers = [
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "License :: OSI Approved :: BSD License",
     "Operating System :: OS Independent",
     "Development Status :: 4 - Beta",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
-sympy-plot-backends~=2.4
-sympy~=1.12
-matplotlib==3.6.*
+sympy-plot-backends>=2.4
+sympy>=1.12
+matplotlib>=3.6
 jupyter>=1.0.0
 numpy>=1.24
 


### PR DESCRIPTION
Updated all version specific dependencies to latest.

Now works and all tests pass under Python 3.12.

sympy-plot-backends no longer requires all these unless it's specified as sympy-plot-backends[all] in the requirements, and that doesn't work because that also pulls vtk, which is no longer installable.