### PR TITLE
Changes to versions for 3.12 to work

### DIFF
--- a/.github/workflows/install_extras.yaml
+++ b/.github/workflows/install_extras.yaml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: ["3.8","3.9","3.10","3.11"] # want to add 3.12 soon
+        python-version: ["3.8","3.9","3.10","3.11","3.12"]
         os: [ubuntu-latest, windows-latest, macos-latest]
         extras:
           - ipympl

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8","3.9","3.10","3.11"] # want to add 3.12 soon
+        python-version: ["3.8","3.9","3.10","3.11","3.12"]
         os: [ubuntu-latest, windows-latest, macos-latest]
 
     steps:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,16 +48,16 @@ build-backend = "setuptools.build_meta"
 
 [project]
 
-version = "2023.1.0"
+version = "2024.1.0"
 
 dependencies = [
-    "sympy-plot-backends~=2.4",
+    "sympy-plot-backends>=2.4,<3",
     "sympy~=1.12", 
     "matplotlib==3.6.*", 
     "jupyter>=1.0.0", 
-    "numpy>=1.24",
+    "numpy>=1.26",
 ]
-requires-python = ">=3.8,<3.12"
+requires-python = ">=3.8"
 
 # generic information
 
@@ -80,6 +80,7 @@ classifiers = [
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "License :: OSI Approved :: BSD License",
     "Operating System :: OS Independent",
     "Development Status :: 4 - Beta",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,9 +55,9 @@ dependencies = [
     "sympy~=1.12", 
     "matplotlib==3.6.*", 
     "jupyter>=1.0.0", 
-    "numpy>=1.26",
+    "numpy>=1.24",
 ]
-requires-python = ">=3.8"
+requires-python = ">=3.8,<3.13"
 
 # generic information
 

--- a/src/dtumathtools/__init__.py
+++ b/src/dtumathtools/__init__.py
@@ -3,6 +3,6 @@ from . import dtutools
 
 __author__ = "Christian Mikkelstrup and Hans Henrik Hermansen"
 __license__ = "BSD-3-Clause"
-__version__ = "2023.1.0"
+__version__ = "2024.1.0"
 
 __all__ = ["dtuplot", "dtutools"]


### PR DESCRIPTION
Notes on changes

- numpy stays at version at version 1.24, but with python 3.12, should automatically pick 1.26 (which is supported as stated [here](https://numpy.org/news/#numpy-1260-released)).
- Allowing sympy-plot-backends to extend up to before 3.0. Version 3.0 and onwards have breaking changes with dtumathtools.
- Reflected changes in packages at [conda-forge](https://github.com/Chrillebon/dtumathtools-feedstock). When merging/changing this branch, it should be reflected there as well. Can only be completed once package is uploaded to pypi, as checks that are being run include downloading the new version from pypi. *Note: changed to a fork and not a branch.*
- Updated version label to 2024.1.0
- Added python 3.12 to workflow.
- Passes all tests (in python 3.12.1). However, pytest has 1 warning related to datetime and python 3.12 in a dateutil package. Comes from sympy-plot-backends, and is thus not a direct result of this package. This is not considered major, and can be ignored.
- Mayavi 4.8.2 has not yet been released. Thus to get dtumathtools onto pypi, the install in pyproject.toml needs to be removed (cannot have install based on path in pypi). Another PR will remove support for mayavi for the spring 24 release.
