### PR TITLE
Remove mayavi support

### DIFF
--- a/.github/workflows/install_extras.yaml
+++ b/.github/workflows/install_extras.yaml
@@ -20,8 +20,8 @@ jobs:
           - bokeh
           - k3d
           - qt
-          - mayavi
           - test
+          # - mayavi # not currently supported
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -22,10 +22,10 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
-
+      # removed mayavi till 4.8.2 comes out (not currently supported)
       - name: Install using flags
         run: |
-          pip install .[ipympl,plotly,bokeh,k3d,qt,mayavi,test]
+          pip install .[ipympl,plotly,bokeh,k3d,qt,test] 
 
       - name: Test with pytest
         run: pytest

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This package is a collection of easy-to-use commands for plotting using SymPy. I
 - 3D plotting of SymPy functions
 - Scatterplots in 2D and 3D
 
-The plotting functions are an extension of *sympy-plot-backends*, and so documentation and examples of plots (for all functions but *dtuplot.scatter()* and *dtuplot.quiver()*) can be found at [sympy-plot-backends.readthedocs.io/](https://sympy-plot-backends.readthedocs.io/en/latest/). Additional functionality and usage is given through course material.
+The plotting functions are an extension of *sympy-plot-backends*, and so documentation and examples of plots (for all functions but *dtuplot.scatter()* and *dtuplot.quiver()*) can be found at [sympy-plot-backends.readthedocs.io/](https://sympy-plot-backends.readthedocs.io/en/v2.4.3/index.html). Additional functionality and usage is given through course material.
 
 ## Installation
 To install dtumathtools using PyPi, run the following command
@@ -23,6 +23,14 @@ All plotting functionality can be found using *dtuplot.xxx* (including all spb p
 
 ## Usage
 Use is designed for the *01001 - Mathematics 1* course at the Technical University of Denmark. Any use-case outside this scope is thus not considered, but very welcome!
+
+## Backends
+Multiple different backends (plotting libraries) can be used (especially helpful for some 3D plots). Currently, [Matplotlib](https://matplotlib.org/) (MB), [Plotly](https://plotly.com/) (PB), [Bokeh](https://github.com/bokeh/bokeh) (BB, *2D only*), and [K3D-Jupyter](https://github.com/K3D-tools/K3D-jupyter) (KB, *3D only*) are supported ([Mayavi](https://docs.enthought.com/mayavi/mayavi/) (MAB, *3D only*) might be supported in the future). The user can change the backend for a plot using the *backend* keyword argument (eg. `backend=dtuplot.PB`), or change the default (here for 3D, but similar for 2D) using:
+
+    dtuplot.cfg["backend_3D"] = "plotly"
+    dtuplot.set_defaults(dtuplot.cfg)
+
+For further descriptions of the strengths and benefits of each, see [this page](https://sympy-plot-backends.readthedocs.io/en/v2.4.3/modules/backends/index.html).
 
 ## Contributing
 You are very welcome to contribute in the way that makes sense to you! The development team will consider all pull requests at the repo [here](https://github.com/dtudk/dtumathtools). For changes to plotting functionality outside *scatter* and *quiver*, direct queries to [spb](https://github.com/Davide-sd/sympy-plot-backends).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,12 +19,14 @@ k3d = [
     "k3d>=2.9.7",
 ]
 qt = ["PyQt5~=5.15.9"]
-mayavi = [
-    "PyQt5~=5.15.9",
-    "vtk",
-    "ipyevents",
-    "mayavi @ git+https://git@github.com/enthought/mayavi",
-]
+# # Variable paths are not compatible with pypi, and
+# # thus mayavi will be unsupported till 4.8.2 is released.
+# mayavi = [
+#     "PyQt5~=5.15.9",
+#     "vtk",
+#     "ipyevents",
+#     "mayavi @ git+https://git@github.com/enthought/mayavi",
+# ]
 
 
 # Customary, the test is for ci-builds

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ numpy>=1.24
 # PyQt5~=5.15.9
 # plotly>=4.14.3
 # ipympl>=0.7.0
-# mayavi>=4.8.0
+# # mayavi>=4.8.2 # Not currently supported
 # ipyevents
 # panel>=1.0.0
 # ipywidgets_bokeh

--- a/src/dtumathtools/dtuplot/quiverplot.py
+++ b/src/dtumathtools/dtuplot/quiverplot.py
@@ -214,6 +214,7 @@ def quiver(*args, **kwargs):
         elif Backend == KB:
             rendering_kw.setdefault("pivot", "tail")
         elif Backend == MAB:
+            warnings.warn(f"Mayavi is not currently supported by dtumathtools.")
             rendering_kw.setdefault("scale_factor", 1)
             rendering_kw.setdefault("resolution", 100)
             display_warning = kwargs.pop("warning", True)

--- a/src/dtumathtools/dtuplot/scatterplot.py
+++ b/src/dtumathtools/dtuplot/scatterplot.py
@@ -126,6 +126,8 @@ def scatter(*args, **kwargs):
         Backend = kwargs.pop("backend", THREE_D_B)
         if Backend == BB:
             raise NotImplementedError("Bokeh does not support 3D scatter plots!")
+        if Backend == MAB:
+            warnings.warn(f"Mayavi is not currently supported by dtumathtools.")
         return plot3d_list(*args, is_point=True, backend=Backend, **kwargs)
 
 

--- a/tests/test_dtuplot.py
+++ b/tests/test_dtuplot.py
@@ -10,6 +10,7 @@ test = 0
 del test
 
 # Disable mayavi tests for github actions, as this fails
+# Reactivate when support for mayavi should return for 4.8.2
 test_mab = False
 
 def test_quiver():


### PR DESCRIPTION
Currently, Mayavi does not work with python 3.12, has limited support in spb, and currently, a git path needs to be used to install a development version of the package for it to work (version needs to be >=4.8.2). Since dtumathtools cannot be uploaded to PyPi with a variable dependency (using a git path), we cannot have Mayavi support and be on PyPi. Because of this, Mayavi is not in the current PyPi package, and so this is not a major change. As it is not part of the course, it should not be a major problem. Hope for support to return as Mayavi 4.8.2 will be released. 

Added a description of backends to the "readme.md" to explain that mayavi is not currently supported, and raise warnings when the mayavi functionality is used.