### PR TITLE
Auto quiver limits kwarg

### DIFF
--- a/src/dtumathtools/dtuplot/quiverplot_helpers.py
+++ b/src/dtumathtools/dtuplot/quiverplot_helpers.py
@@ -30,8 +30,12 @@ def MB_update_quiver2d_helper(renderer, data, handle):
 
 
 class MBQuiver2DRenderer(MatplotlibRenderer):
-    _sal = True
     draw_update_map = {MB_draw_quiver2d_helper: MB_update_quiver2d_helper}
+    
+    def __init__(self, plot, s):
+        super().__init__(plot,s)
+        # set "_sal" based off series
+        self._sal = s._sal
 
 
 def MB_draw_quiver3d_helper(renderer, data):
@@ -51,8 +55,12 @@ def MB_update_quiver3d_helper(renderer, data, handle):
 
 
 class MBQuiver3DRenderer(MatplotlibRenderer):
-    _sal = True
     draw_update_map = {MB_draw_quiver3d_helper: MB_update_quiver3d_helper}
+    
+    def __init__(self, plot, s):
+        super().__init__(plot,s)
+        # set "_sal" based off series
+        self._sal = s._sal
 
 
 # Plotly

--- a/tests/test_dtuplot.py
+++ b/tests/test_dtuplot.py
@@ -52,6 +52,8 @@ def test_quiver():
     dtuplot.quiver(np.array([1, 2, 3]), Matrix([1, 2, 3]), backend=PB, show=False)
     dtuplot.quiver([1, 2, 3], Matrix([1, 2, 3]), label="123", backend=PB, show=False)
     dtuplot.quiver([1, 2, 3], Matrix([1, 2, 3]), label=["123"], backend=PB, show=False)
+    dtuplot.quiver([1, 2, 3], [4, 5, 6], backend=PB, qlim=False, show=False)
+    dtuplot.quiver([1, 2], [4, 5], backend=PB, qlim=False, show=False)
     # bokeh
     dtuplot.quiver([1, 2], [4, 5], backend=BB, show=False)
     dtuplot.quiver(Matrix([1, 2]), Matrix([4, 5]), backend=BB, show=False)
@@ -60,6 +62,7 @@ def test_quiver():
     dtuplot.quiver(np.array([1, 2]), (1, 2), backend=BB, show=False)
     dtuplot.quiver(np.array([1, 2]), np.array([1, 2]), backend=BB, show=False)
     dtuplot.quiver(np.array([1, 2]), Matrix([1, 2]), backend=BB, show=False)
+    dtuplot.quiver([1, 2], [4, 5], backend=BB, qlim=False, show=False)
     # k3d
     with pytest.warns(
         UserWarning, match="K3DBackend only works properly within Jupyter Notebook"
@@ -76,6 +79,7 @@ def test_quiver():
         dtuplot.quiver(
             [1, 2, 3], Matrix([1, 2, 3]), label=["123"], backend=KB, show=False
         )
+        dtuplot.quiver([1, 2, 3], [4, 5, 6], backend=KB, qlim=False, show=False)
     # mayavi
     if test_mab:
         # A lot of things in the Mayavi toolbox is deprecated...
@@ -120,6 +124,14 @@ def test_quiver():
                 backend=MAB,
                 show=False,
                 warning=False,
+            )
+            dtuplot.quiver(
+                [1, 2, 3],
+                [4, 5, 6],
+                backend=MAB,
+                qlim=False,
+                show=False,
+                warning=False
             )
 
         with pytest.raises(

--- a/tests/test_dtuplot.py
+++ b/tests/test_dtuplot.py
@@ -34,6 +34,8 @@ def test_quiver():
     dtuplot.quiver(np.array([1, 2, 3]), Matrix([1, 2, 3]), backend=MB, show=False)
     dtuplot.quiver([1, 2, 3], Matrix([1, 2, 3]), label="123", backend=MB, show=False)
     dtuplot.quiver([1, 2, 3], Matrix([1, 2, 3]), label=["123"], backend=MB, show=False)
+    dtuplot.quiver([1, 2, 3], [4, 5, 6], backend=MB, qlim=False, show=False)
+    dtuplot.quiver([1, 2], [4, 5], backend=MB, qlim=False, show=False)
     # plotly
     dtuplot.quiver(Matrix([1, 2, 3]), Matrix([4, 5, 6]), show=False, backend=PB)
     dtuplot.quiver([1, 2, 3], [4, 5, 6], backend=PB, show=False)


### PR DESCRIPTION
# Description
Possible solution to [this issue](https://github.com/dtudk/dtumathtools/issues/26). Added an optional argument (defaults to True): "qlim", which automatically adjusts the limits of the plot to the quiver. This argument is only used with the matplotlib backend, as none of the other backends have problems adjusting limits with quivers.

# Changes in code
Pulls "qlim" from the keyword arguments in the quiver function, and passes it onto all relevant "series" objects. The series object then passes the argument to the renderer (which previously always had `_sal=True`), where a value of `True` adjusts the limits of the plot based on the data. The argument has to go through the series, as "adding" multiple plots creates new renderers based on the series objects. Also added a simple test to ensure that this argument does not crash the plot.

# Changes in output
In the **Code block**, the keyword argument has been added, resulting in **Plot A**, compared to the previous result in **Plot B**. **Plot C** is included to show the intended behavior of `p4.show()`, which is a problem that has been [located and adressed](https://github.com/Davide-sd/sympy-plot-backends/pull/30), and will give this behavior when sympy-plot-backends is updated to version `>= 3.0`

# What this PR does not fix
This PR simply gives the user the option of turning off the "auto limits" generated as a fix to the poor auto-limits by matplotlib. This also means that it does nothing to fix a potential problem where quivers that point outside of all other automatic limits will be cropped. For this, one can still manually adjust the limits of a plot using `p.xlim = ['start', 'end']` and `p.ylim = ['start', 'end']` before `p.show()`

## Code block
```
from dtumathtools import *
from sympy import *
init_printing()

u, t = symbols('u t', real=True)
r = Matrix([u*cos(u), u*sin(u)])
rd = diff(r,u)
u0 = 3*pi/2
rdu0 = rd.subs(u,u0)
ru0 = r.subs(u,u0)
T = ru0 + t*rdu0

p1 = dtuplot.plot_parametric(r[0], r[1],(u,0,4*pi),rendering_kw={"color":"red"},use_cm=False,backend=dtuplot.MB,show=False)
p2 = dtuplot.plot_parametric(T[0],T[1],(t,-1.5,1.5),rendering_kw={"color":"royalblue"},use_cm=False,backend=dtuplot.MB,show=False)
p3 = dtuplot.scatter(ru0,rendering_kw={"markersize":10,"color":'black'},backend=dtuplot.MB,show=False)
p4 = dtuplot.quiver(ru0,rdu0,rendering_kw={"color":"black"},qlim=False,backend=dtuplot.MB,show=False)
p = p1+p2+p3+p4

p4.show()
p.show()
```

## Plot A
![image](https://github.com/dtudk/dtumathtools/assets/32595016/b257f36c-132e-47ad-8c7a-cdecd341ee3d)
![image](https://github.com/dtudk/dtumathtools/assets/32595016/ee5094dd-313a-4d5d-9a11-215b3db8761d)

## Plot B
![image](https://github.com/dtudk/dtumathtools/assets/32595016/022192fe-74f2-4276-9c35-bde044bceb8a)
![image](https://github.com/dtudk/dtumathtools/assets/32595016/87648c9f-a453-4bbc-a5ad-4e904360c88d)

## Plot C
![image](https://github.com/dtudk/dtumathtools/assets/32595016/7fb1fcca-4b32-43d7-8175-a5df5c0bc8d4)
