### PR TITLE
2024.2

### DIFF
--- a/.github/workflows/install_extras.yaml
+++ b/.github/workflows/install_extras.yaml
@@ -22,7 +22,7 @@ jobs:
           - k3d
           - qt
           - test
-          - mayavi
+          # - mayavi # No wheel for 4.8.2, so does not work with --only-binary
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/install_extras.yaml
+++ b/.github/workflows/install_extras.yaml
@@ -37,4 +37,4 @@ jobs:
 
       - name: Install using flags
         run: |
-          python3 -m pip install -v .[${{ matrix.extras }}]
+          python3 -m pip install -v --only-binary=:all: .[${{ matrix.extras }}]

--- a/.github/workflows/install_extras.yaml
+++ b/.github/workflows/install_extras.yaml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8","3.9","3.10","3.11","3.12"]
+        python-version: ["3.9","3.10","3.11","3.12"]
         os: [ubuntu-latest, windows-latest, macos-latest]
         extras:
           - ipympl
@@ -22,11 +22,7 @@ jobs:
           - k3d
           - qt
           - test
-          # - mayavi # not currently supported
-        exclude:
-          - python-version: "3.8"
-            os: "macos-latest"
-            extras: "k3d"
+          - mayavi
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/install_extras.yaml
+++ b/.github/workflows/install_extras.yaml
@@ -5,6 +5,8 @@ on:
     branches: [ "main", "b*" ]
   pull_request:
     branches: [ "main", "b*" ]
+  schedule:
+    - cron: "0 16 * * 4" # Every Thursday at 16 UTC (17 CET/18 CEST)
 
 jobs:
   build:

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -24,7 +24,7 @@ jobs:
 
       - name: Install using flags
         run: |
-          python3 -m pip install -v .[dev]
+          python3 -m pip install -v --only-binary=:all: .[dev]
 
       - name: Lint with flake8
         run: |

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -13,11 +13,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8","3.9","3.10","3.11","3.12"]
+        python-version: ["3.9","3.10","3.11","3.12"]
         os: [ubuntu-latest, windows-latest, macos-latest]
-        exclude:
-          - python-version: "3.8"
-            os: "macos-latest"
 
     steps:
       - uses: actions/checkout@v4
@@ -30,10 +27,9 @@ jobs:
         run: |
           python3 -m pip install --upgrade pip
 
-      # removed mayavi till 4.8.2 comes out (not currently supported)
       - name: Install using flags
         run: |
-          python3 -m pip install -v .[ipympl,plotly,bokeh,k3d,qt,test]
+          python3 -m pip install -v .[ipympl,plotly,bokeh,k3d,mayavi,qt,test]
 
       - name: Test with pytest
         run: |

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -5,6 +5,8 @@ on:
     branches: [ "main", "b*" ]
   pull_request:
     branches: [ "main", "b*" ]
+  schedule:
+    - cron: "0 16 * * 4" # Every Thursday at 16 UTC (17 CET/18 CEST)
 
 jobs:
   build:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -29,7 +29,7 @@ jobs:
 
       - name: Install using flags
         run: |
-          python3 -m pip install -v .[ipympl,plotly,bokeh,k3d,mayavi,qt,test]
+          python3 -m pip install -v --only-binary=:all: .[ipympl,plotly,bokeh,k3d,mayavi,qt,test]
 
       - name: Test with pytest
         run: |

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -29,7 +29,7 @@ jobs:
 
       - name: Install using flags
         run: |
-          python3 -m pip install -v --only-binary=:all: .[ipympl,plotly,bokeh,k3d,mayavi,qt,test]
+          python3 -m pip install -v --only-binary=:all: .[ipympl,plotly,bokeh,k3d,qt,test]
 
       - name: Test with pytest
         run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,8 @@ build-backend = "setuptools.build_meta"
 version = "2024.2.0"
 
 dependencies = [
-    "sympy-plot-backends>=3.1.1,<3.3",
+    'sympy-plot-backends>=3.1.1,<3.3;python_version<="3.9"',
+    'sympy-plot-backends>=3.4,<4.0;python_version>="3.10"',
     "sympy~=1.12", 
     "matplotlib==3.9.*", 
     "jupyter>=1.0.0", 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,13 +21,15 @@ k3d = [
     "k3d>=2.9.7",
 ]
 qt = ["PyQt5~=5.15.9"]
-mayavi = [
-    "PyQt5~=5.15.9",
-    "vtk",
-    "ipyevents",
-    "mayavi==4.8.2",
-    "configobj",
-]
+# # Mayavi is not currently supported
+# # The following list is the known requirements
+# mayavi = [
+#     "PyQt5~=5.15.9",
+#     "vtk",
+#     "ipyevents",
+#     "mayavi==4.8.2",
+#     "configobj",
+# ]
 
 
 # Customary, the test is for ci-builds

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,7 +59,7 @@ dependencies = [
     'sympy-plot-backends>=3.1.1,<3.3;python_version<="3.9"',
     'sympy-plot-backends>=3.4,<4.0;python_version>="3.10"',
     "sympy~=1.12", 
-    "matplotlib==3.9.*", 
+    "matplotlib>=3.8,<3.10", 
     "jupyter>=1.0.0", 
     "numpy>=1.24,<2",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,7 @@ build-backend = "setuptools.build_meta"
 version = "2024.2.0"
 
 dependencies = [
-    "sympy-plot-backends>=2.4,<3",
+    "sympy-plot-backends>=3.1.1,<3.3",
     "sympy~=1.12", 
     "matplotlib==3.9.*", 
     "jupyter>=1.0.0", 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,14 +21,13 @@ k3d = [
     "k3d>=2.9.7",
 ]
 qt = ["PyQt5~=5.15.9"]
-# # Variable paths are not compatible with pypi, and
-# # thus mayavi will be unsupported till 4.8.2 is released.
-# mayavi = [
-#     "PyQt5~=5.15.9",
-#     "vtk",
-#     "ipyevents",
-#     "mayavi @ git+https://git@github.com/enthought/mayavi",
-# ]
+mayavi = [
+    "PyQt5~=5.15.9",
+    "vtk",
+    "ipyevents",
+    "mayavi==4.8.2",
+    "configobj",
+]
 
 
 # Customary, the test is for ci-builds
@@ -52,16 +51,16 @@ build-backend = "setuptools.build_meta"
 
 [project]
 
-version = "2024.1.0"
+version = "2024.2.0"
 
 dependencies = [
     "sympy-plot-backends>=2.4,<3",
     "sympy~=1.12", 
-    "matplotlib==3.6.*", 
+    "matplotlib==3.9.*", 
     "jupyter>=1.0.0", 
     "numpy>=1.24,<2",
 ]
-requires-python = ">=3.8,<3.13"
+requires-python = ">=3.9,<3.13"
 
 # generic information
 
@@ -80,14 +79,13 @@ license = {text = "BSD-3-Clause"}
 
 classifiers = [
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "License :: OSI Approved :: BSD License",
     "Operating System :: OS Independent",
-    "Development Status :: 4 - Beta",
+    "Development Status :: 5 - Production/Stable",
     "Intended Audience :: Education",
     "Topic :: Education",
     "Topic :: Scientific/Engineering :: Mathematics",

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,1 +1,1 @@
-.[ipympl,plotly,bokeh,k3d,qt,mayavi,test,dev]
+.[ipympl,plotly,bokeh,k3d,qt,test,dev]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,1 +1,1 @@
-.[ipympl,plotly,bokeh,k3d,qt,test,dev]
+.[ipympl,plotly,bokeh,k3d,qt,mayavi,test,dev]

--- a/src/dtumathtools/dtuplot/__init__.py
+++ b/src/dtumathtools/dtuplot/__init__.py
@@ -1,41 +1,64 @@
 from spb import *
-from .quiverplot import quiver, Arrow2DSeries, Arrow3DSeries
-from .scatterplot import scatter
+from spb.defaults import (
+    cfg,  # can still be imported though not recognized
+    get_default_settings,
+    set_defaults,
+)
+
 from .boundaryplot import plot_boundary
-from spb.defaults import get_default_settings, cfg, set_defaults
+from .quiverplot import Arrow2DSeries, Arrow3DSeries, quiver
 
 # Backends to support the vector plotting functionality.
 from .quiverplot_helpers import (
-    MBQuiver2DRenderer as MBV2,
-    MBQuiver3DRenderer as MBV3,
-    PBQuiver2DRenderer as PBV2,
-    PBQuiver3DRenderer as PBV3,
     BBQuiver2DRenderer as BBV2,
-    KBQuiver3DRenderer as KBV3,
-    MABQuiver3DRenderer as MABV3
 )
+from .quiverplot_helpers import (
+    KBQuiver3DRenderer as KBV3,
+)
+from .quiverplot_helpers import (
+    MABQuiver3DRenderer as MABV3,
+)
+from .quiverplot_helpers import (
+    MBQuiver2DRenderer as MBV2,
+)
+from .quiverplot_helpers import (
+    MBQuiver3DRenderer as MBV3,
+)
+from .quiverplot_helpers import (
+    PBQuiver2DRenderer as PBV2,
+)
+from .quiverplot_helpers import (
+    PBQuiver3DRenderer as PBV3,
+)
+from .scatterplot import scatter
 
-MB.renderers_map.update({
-    Arrow2DSeries: MBV2,
-    Arrow3DSeries: MBV3,
-})
-PB.renderers_map.update({
-    Arrow2DSeries: PBV2,
-    Arrow3DSeries: PBV3,
-})
-BB.renderers_map.update({
-    Arrow2DSeries: BBV2,
-})
-KB.renderers_map.update({
-    Arrow3DSeries: KBV3,
-})
-MAB.renderers_map.update({
-    Arrow3DSeries: MABV3
-})
+MB.renderers_map.update(
+    {
+        Arrow2DSeries: MBV2,
+        Arrow3DSeries: MBV3,
+    }
+)
+PB.renderers_map.update(
+    {
+        Arrow2DSeries: PBV2,
+        Arrow3DSeries: PBV3,
+    }
+)
+BB.renderers_map.update(
+    {
+        Arrow2DSeries: BBV2,
+    }
+)
+KB.renderers_map.update(
+    {
+        Arrow3DSeries: KBV3,
+    }
+)
+MAB.renderers_map.update({Arrow3DSeries: MABV3})
 
 # Update Mayavi functionality to support scatter plotting
-from .scatterplot import Point3DRenderer
 from spb.series import List3DSeries
-MAB.renderers_map.update({
-    List3DSeries: Point3DRenderer
-})
+
+from .scatterplot import Point3DRenderer
+
+MAB.renderers_map.update({List3DSeries: Point3DRenderer})

--- a/src/dtumathtools/dtuplot/__init__.py
+++ b/src/dtumathtools/dtuplot/__init__.py
@@ -8,57 +8,23 @@ from spb.defaults import (
 from .boundaryplot import plot_boundary
 from .quiverplot import Arrow2DSeries, Arrow3DSeries, quiver
 
-# Backends to support the vector plotting functionality.
-from .quiverplot_helpers import (
-    BBQuiver2DRenderer as BBV2,
-)
-from .quiverplot_helpers import (
-    KBQuiver3DRenderer as KBV3,
-)
-from .quiverplot_helpers import (
-    MABQuiver3DRenderer as MABV3,
-)
-from .quiverplot_helpers import (
-    MBQuiver2DRenderer as MBV2,
-)
-from .quiverplot_helpers import (
-    MBQuiver3DRenderer as MBV3,
-)
+# Change plotting function and renderer for plotly when
+# plotting quivers/arrows. This allows for plotting of 
+# 3D vectors.
+
 from .quiverplot_helpers import (
     PBQuiver2DRenderer as PBV2,
+    Arrow2DSeries as PB_Arrow2DSeries,
 )
 from .quiverplot_helpers import (
     PBQuiver3DRenderer as PBV3,
+    Arrow3DSeries as PB_Arrow3DSeries,
 )
 from .scatterplot import scatter
 
-MB.renderers_map.update(
-    {
-        Arrow2DSeries: MBV2,
-        Arrow3DSeries: MBV3,
-    }
-)
 PB.renderers_map.update(
     {
-        Arrow2DSeries: PBV2,
-        Arrow3DSeries: PBV3,
+        PB_Arrow2DSeries: PBV2,
+        PB_Arrow3DSeries: PBV3,
     }
 )
-BB.renderers_map.update(
-    {
-        Arrow2DSeries: BBV2,
-    }
-)
-KB.renderers_map.update(
-    {
-        Arrow3DSeries: KBV3,
-    }
-)
-MAB.renderers_map.update({Arrow3DSeries: MABV3})
-
-# Update Mayavi functionality to support scatter plotting
-from spb.series import List3DSeries
-
-from .scatterplot import Point3DRenderer
-
-MAB.renderers_map.update({List3DSeries: Point3DRenderer})

--- a/src/dtumathtools/dtuplot/boundaryplot.py
+++ b/src/dtumathtools/dtuplot/boundaryplot.py
@@ -1,4 +1,4 @@
-from spb.functions import plot_parametric
+from spb import plot_parametric
 from sympy.matrices import MatrixBase
 from spb.backends.base_backend import Plot
 

--- a/src/dtumathtools/dtuplot/quiverplot.py
+++ b/src/dtumathtools/dtuplot/quiverplot.py
@@ -1,81 +1,15 @@
 from spb import MB, PB, BB, KB, MAB
 from spb.defaults import THREE_D_B, TWO_D_B
 from spb.plot_functions.functions_2d import _set_labels
-from spb.series import VectorBase
 from spb.utils import _instantiate_backend
-from sympy import Matrix, latex, symbols
+from sympy import Matrix
 from sympy.external import import_module
-from spb.backends.base_backend import Plot
 import warnings
+from spb.series import Arrow2DSeries, Arrow3DSeries
+from .quiverplot_helpers import Arrow2DSeries as PB_Arrow2DSeries, Arrow3DSeries as PB_Arrow3DSeries
 
 np = import_module("numpy")
-
-
-class ArrowSeries(VectorBase):
-    """Represent a vector field."""
-
-    is_vector = True
-    is_slice = False
-    is_streamlines = False
-    _allowed_keys = []
-
-    def __init__(self, start, direction, label=None, **kwargs):
-        # Ranges must be given for VectorBase, even though they are None
-        super().__init__(
-            [start, direction], ranges=start.shape[-1] * [None], label=label, **kwargs
-        )
-
-        self.start = start
-        self.direction = direction
-
-        self._label = f"{start}->{direction}" if label is None else label
-        self._latex_label = latex(f"{start}->{direction}") if label is None else label
-
-        # Standard for 'use_cm' should be False
-        self.use_cm = kwargs.get("use_cm", False)
-        # Linked colormap using vector2d renderer
-        self.use_quiver_solid_color = not self.use_cm
-        # Line color needed for Mayavi
-        self._line_color = kwargs.get("line_color", None)
-        # _sal argument saved here and passed to matplotlib backend (if used)
-        self._sal = kwargs.get("_sal", False)
-
-    def __str__(self):
-        # Overwrite the VectorBase __str__ as it assumes things
-        # about variables that does not hold for this class.
-        return self._str_helper(
-            f"Arrow Series with start point {self.start}, and direction {self.direction}"
-        )
-
-    def get_data(self):
-        # This format works for both MB and PB
-        # Has to translate to start/end and transpose
-        # such that the x,y,z lims match the arrow
-        # compensation for this in arrow done in
-        # quiverplot_helpers.
-        start = np.array(self.start)
-        end = start + np.array(self.direction)
-        return np.array(
-            [start, end]
-        ).T  # [np.array([v]) for v in list(self.start) + list(self.direction)]
-
-
-# Specify 2D class such that this can be linked with renderer
-class Arrow2DSeries(ArrowSeries):
-    is_2Dvector = True
-
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-
-
-# Specify 3D class such that this can be linked with renderer
-class Arrow3DSeries(ArrowSeries):
-    is_3Dvector = True
-
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-
-
+        
 def quiver(*args, **kwargs):
     """Create a plot with a vector.
 
@@ -83,7 +17,7 @@ def quiver(*args, **kwargs):
         start (MatrixBase, np.ndarray, list, float): The starting coordinates (2D or 3D) of the vector. Can be given in multitude of ways/inputs.
         direction (MatrixBase, np.ndarray, list, float): The direction (2D or 3D) of the vector. Can be given in multitude of ways/inputs.
         rendering_kw (dict, optional): A dictionary forwarded to dtuplot.plot(), see SPB docs for reference.
-        qlim (bool, optional): Boolean relevant only for backend MB. If 'True' (default) adjusts xlim and ylim to the quiver.
+        qlim (bool, optional): Boolean relevant only for backend MB. If 'True' (default is False) adjusts xlim and ylim (and zlim) to the quiver.
         color (str, optional): A string to set the color of the vector with. With no argument color = 'blue'.
         show (bool, optional): Boolean, if 'True': show plot, other just return object without plotting. Defaults to 'True'.
 
@@ -124,13 +58,13 @@ def quiver(*args, **kwargs):
         if type(args[i]) in [list, np.ndarray, tuple, type(Matrix())]:
             newpoint = np.array(args[i]).flatten()
             point_args.append(newpoint)
-        elif type(args[i]) == dict:
+        elif isinstance(args[i], dict):
             kwargs.setdefault("rendering_kw", args[i])
         else:
             otherargs.append(args[i])
     assert (
         len(point_args) == 2
-    ), f"Error! Start and direction vectors must be provided (only two vectors)!"
+    ), "Error! Start and direction vectors must be provided (only two vectors)!"
 
     try:
         point_args = np.array(point_args, dtype=float)
@@ -149,7 +83,14 @@ def quiver(*args, **kwargs):
     if len(point_args.shape) == 2:
         point_args = point_args[:, None, :]
 
+    # rendering_kw needs to be passed to the plotting backend, but not
+    # to the series. Thus pulled out here.
+    # Create if it does not exist
+    rendering_kw = kwargs.pop("rendering_kw", {})
+
     labels = kwargs.pop("label", [])
+    # Look in rendering_kw if not found as seperate argument
+    labels = rendering_kw.pop("label", []) if labels == [] else labels
     if type(labels) == str:
         labels = [labels]
     assert type(labels) == list, f"Error! Label must be a list or a string!"
@@ -158,9 +99,15 @@ def quiver(*args, **kwargs):
         point_args.shape[1],
     ], f"Error! Number of labels must be equal to number of arrows, or empty list!"
     if labels == []:
-        labels = [None] * point_args.shape[1]
+        labels = [""] * point_args.shape[1]
+        kwargs.setdefault("legend", False)
+    else:
+        # Label is given, so set legend=True as default
+        kwargs.setdefault("legend", True)
+        # If given as latex code already, do not wrap in additional $ later
+        if labels[0][0] == "$":
+            kwargs.setdefault("use_latex", False)
 
-    kwargs.setdefault("legend", True)
     # params are directly linked with interactive plots
     # if present, the BaseSeries will activate the 'is_interactive' flag
     params = kwargs.get("params", None)
@@ -171,63 +118,74 @@ def quiver(*args, **kwargs):
 
         kwargs["is_vector"] = True
         return iplot(*args, **kwargs)
-
-    # rendering_kw needs to be passed to the plotting backend, but not
-    # to the series. Thus pulled out here.
-    # Create if it does not exist
-    rendering_kw = kwargs.pop("rendering_kw", {})
     # normalize argument needs to be passed to series object, but not to
     # backend. Otherwise warning will be raised. Thus pulled out here.
     normalize = kwargs.pop("normalize", False)
-    # automatically adjust the limits to the quiver. Only relevant for MB.
-    # saved in series, which propagates to the renderer when created.
-    qlim = kwargs.pop("qlim", True)
-
+    
     # if 2D
     if point_args.shape[-1] == 2:
         Backend = kwargs.pop("backend", TWO_D_B)
-        Series = Arrow2DSeries
 
-        # Specific for matplotlib backend
-        if Backend == MB:
-            # Update values for length of vector to fit
-            rendering_kw.setdefault("angles", "xy")
-            rendering_kw.setdefault("scale_units", "xy")
-            rendering_kw.setdefault("scale", 1)
-        elif Backend == PB:
+        # Specific arguments for backends
+        if Backend == PB:
             rendering_kw.setdefault("scale", 1)
             rendering_kw.setdefault("scaleratio", 1)
-        elif Backend == BB:
-            mag = np.linalg.norm(point_args[-1].flatten(), 2)
-            rendering_kw.setdefault("scale", mag)
-            rendering_kw.setdefault("pivot", "tail")
-        elif Backend == KB:
+            # I do not like how plotly is handled in spb,
+            # so for PB, we use the older solution that works well
+            Series = PB_Arrow2DSeries
+        else:
+            Series = Arrow2DSeries
+            
+        if Backend == KB:
             raise NotImplementedError("K3D backend does not support 2D vector plots!")
-        elif Backend == MAB:
+        if Backend == MAB:
             raise NotImplementedError(
                 "Mayavi backend does not support 2D vector plots!"
             )
     else:
         Backend = kwargs.pop("backend", THREE_D_B)
-        Series = Arrow3DSeries
 
         if Backend == PB:
             rendering_kw.setdefault("sizeref", 1)
             rendering_kw.setdefault("sizemode", "scaled")
-            rendering_kw.setdefault("anchor", "tail")  # point_args[0,0]
-        elif Backend == BB:
+            rendering_kw.setdefault("anchor", "tail")
+            # I do not like how plotly is handled in spb (does not work in 3D)
+            # so for PB, we use the older solution that works well
+            Series = PB_Arrow3DSeries
+        else:
+            Series = Arrow3DSeries
+        if Backend == BB:
             raise NotImplementedError("Bokeh backend does not support 3D vector plots!")
-        elif Backend == KB:
-            rendering_kw.setdefault("pivot", "tail")
-        elif Backend == MAB:
+
+        if Backend == MAB:
             warnings.warn("Mayavi is not currently supported by dtumathtools.")
-            rendering_kw.setdefault("scale_factor", 1)
-            rendering_kw.setdefault("resolution", 100)
             display_warning = kwargs.pop("warning", True)
             if display_warning:
                 warnings.warn(
-                    f"Because of the Mayavi backend, the origin of the vector might be slightly off. To supress this warning, set 'warning=False'"
+                    "Because of the Mayavi backend, the origin of the vector might be slightly off. "+\
+                        "To supress this warning, set 'warning=False'"
                 )
+    
+    if "qlim" not in kwargs and "xlim" not in kwargs and "ylim" not in kwargs and point_args.shape[-1] == 3 and Backend == MB:
+        warnings.warn("Warning: Limits were not given for a 3D quiver using Matplotlib. "+\
+            "The quiver might not be in frame. Consider manually setting the limits, or set 'qlim=True'.")
+    # automatically adjust the limits to the quiver. Only relevant for MB.
+    # saved in series, which propagates to the renderer when created.
+    qlim = kwargs.pop("qlim", False)
+    
+    # Automatically adjust limits (if not already given) if qlim=True
+    if Backend == MB and qlim:
+        margin = kwargs.pop("margin", 0.05)
+        # lower and upper boundaries of limits
+        minlim, maxlim = point_args[0].copy(), point_args[0].copy()
+        # tmp = minlim.copy()
+        minlim[point_args[1]<0] += point_args[1][point_args[1]<0]
+        maxlim[point_args[1]>0] += point_args[1][point_args[1]>0]
+        # minlim = tmp
+        kwargs.setdefault("xlim", [np.nanmin(minlim[:,0])-margin, np.nanmax(maxlim[:,0])+margin])
+        kwargs.setdefault("ylim", [np.nanmin(minlim[:,1])-margin, np.nanmax(maxlim[:,1])+margin])
+        if point_args.shape[-1] == 3:
+            kwargs.setdefault("zlim", [np.nanmin(minlim[:,2])-margin, np.nanmax(maxlim[:,2])+margin])
 
     series = [
         Series(
@@ -236,12 +194,12 @@ def quiver(*args, **kwargs):
             *otherargs,
             label=label,
             normalize=normalize,
-            _sal=(qlim and Backend == MB),  # save qlim kwarg in series object (if MB)
+            show_in_legend=False if label=="" else True, # remove legend if no label
             **kwargs,
         )
         for start, stop, label in zip(point_args[0, :, :], point_args[1, :, :], labels)
     ]
-
+    
     _set_labels(series, labels, rendering_kw)
 
     # if multiple arrows are given, plot them all in one plot

--- a/src/dtumathtools/dtuplot/quiverplot.py
+++ b/src/dtumathtools/dtuplot/quiverplot.py
@@ -220,6 +220,7 @@ def quiver(*args, **kwargs):
         elif Backend == KB:
             rendering_kw.setdefault("pivot", "tail")
         elif Backend == MAB:
+            warnings.warn("Mayavi is not currently supported by dtumathtools.")
             rendering_kw.setdefault("scale_factor", 1)
             rendering_kw.setdefault("resolution", 100)
             display_warning = kwargs.pop("warning", True)

--- a/src/dtumathtools/dtuplot/quiverplot.py
+++ b/src/dtumathtools/dtuplot/quiverplot.py
@@ -220,7 +220,6 @@ def quiver(*args, **kwargs):
         elif Backend == KB:
             rendering_kw.setdefault("pivot", "tail")
         elif Backend == MAB:
-            warnings.warn(f"Mayavi is not currently supported by dtumathtools.")
             rendering_kw.setdefault("scale_factor", 1)
             rendering_kw.setdefault("resolution", 100)
             display_warning = kwargs.pop("warning", True)
@@ -236,9 +235,10 @@ def quiver(*args, **kwargs):
             *otherargs,
             label=label,
             normalize=normalize,
-            _sal=(qlim and Backend==MB), # save qlim kwarg in series object (if MB)
+            _sal=(qlim and Backend == MB),  # save qlim kwarg in series object (if MB)
             **kwargs,
-        ) for start, stop, label in zip(point_args[0, :, :], point_args[1, :, :], labels)
+        )
+        for start, stop, label in zip(point_args[0, :, :], point_args[1, :, :], labels)
     ]
 
     _set_labels(series, labels, rendering_kw)

--- a/src/dtumathtools/dtuplot/quiverplot.py
+++ b/src/dtumathtools/dtuplot/quiverplot.py
@@ -1,6 +1,6 @@
 from spb import MB, PB, BB, KB, MAB
 from spb.defaults import THREE_D_B, TWO_D_B
-from spb.functions import _set_labels
+from spb.plot_functions.functions_2d import _set_labels
 from spb.series import VectorBase
 from spb.utils import _instantiate_backend
 from sympy import Matrix, latex, symbols

--- a/src/dtumathtools/dtuplot/scatterplot.py
+++ b/src/dtumathtools/dtuplot/scatterplot.py
@@ -126,6 +126,8 @@ def scatter(*args, **kwargs):
         Backend = kwargs.pop("backend", THREE_D_B)
         if Backend == BB:
             raise NotImplementedError("Bokeh does not support 3D scatter plots!")
+        if Backend == MAB:
+            warnings.warn("Mayavi is not currently supported by dtumathtools.")
         return plot3d_list(*args, is_point=True, backend=Backend, **kwargs)
 
 

--- a/src/dtumathtools/dtuplot/scatterplot.py
+++ b/src/dtumathtools/dtuplot/scatterplot.py
@@ -126,8 +126,6 @@ def scatter(*args, **kwargs):
         Backend = kwargs.pop("backend", THREE_D_B)
         if Backend == BB:
             raise NotImplementedError("Bokeh does not support 3D scatter plots!")
-        if Backend == MAB:
-            warnings.warn(f"Mayavi is not currently supported by dtumathtools.")
         return plot3d_list(*args, is_point=True, backend=Backend, **kwargs)
 
 

--- a/src/dtumathtools/dtuplot/scatterplot.py
+++ b/src/dtumathtools/dtuplot/scatterplot.py
@@ -1,6 +1,6 @@
 from sympy import MatrixBase, Expr, Basic, MutableMatrix, ImmutableMatrix
 from sympy.external import import_module
-from spb.functions import plot_list, plot3d_list
+from spb import plot_list, plot3d_list
 from spb.backends.base_backend import Plot
 import numpy as np
 from spb import MB, PB, BB, KB, MAB

--- a/tests/test_F_demos.py
+++ b/tests/test_F_demos.py
@@ -202,7 +202,9 @@ def test_week1():
             a0, rendering_kw={"alpha": 1, "s": 100, "color": "black"}, show=False
         )
     )
-    p.extend(dtuplot.quiver(a0, N, {"color": "red"}, show=False))
+    # Added qlim argument here to avoid warning. However, this does not
+    # affect the demos, as this is not in the demos (currently)
+    p.extend(dtuplot.quiver(a0, N, {"color": "red"}, show=False,qlim=False))
 
     x, y, u = symbols("x y u")
     f = x**2 / 10 + y**2 / 10 + 10
@@ -234,6 +236,8 @@ def test_week1():
             r1[0], r1[1], 0, rendering_kw={"color": "black", "s": 100}, show=False
         )
     )
+    # Added qlim argument here to avoid warning. However, this does not
+    # affect the demos, as this is not in the demos (currently)
     p.extend(
         dtuplot.quiver(
             r1[0],
@@ -244,6 +248,7 @@ def test_week1():
             f.subs({x: r1[0], y: r1[1]}),
             rendering_kw={"color": "orange"},
             show=False,
+            qlim=False,
         )
     )
     r2 = r.subs(u, 3 * pi / 2)
@@ -262,6 +267,7 @@ def test_week1():
             f.subs({x: r2[0], y: r2[1]}),
             rendering_kw={"color": "orange"},
             show=False,
+            qlim=False,
         )
     )
 
@@ -377,12 +383,15 @@ def test_week1():
         rendering_kw={"alpha": 0.35, "color": "blue"},
         show=False,
     )
-    p_normalvector = dtuplot.quiver(p0, n4, rendering_kw={"color": "red"}, show=False)
+    # Added qlim argument here to avoid warning. However, this does not
+    # affect the demos, as this is not in the demos (currently)
+    p_normalvector = dtuplot.quiver(p0, n4, rendering_kw={"color": "red"}, show=False,qlim=False)
     p_arrow_along_plane = dtuplot.quiver(
         p0,
         [e[0], e[1], f.subs({x: 1, y: -1})],
         rendering_kw={"color": "orange"},
         show=False,
+        qlim=False,
     )
     res = p_parab + p_point + p_vertical_plane + p_normalvector + p_arrow_along_plane
 
@@ -1148,11 +1157,14 @@ def test_week6():
         use_cm=False,
         rendering_kw={"color": "grey", "linestyle": "dashed"},
     )
+    # Added qlim argument here to avoid warning. However, this does not
+    # affect the demos, as this is not in the demos (currently)
     pil3d = dtuplot.quiver(
         Matrix([0.3, 0.375, 0]),
         Matrix([0, 0, 0.375]),
         show=False,
         rendering_kw={"color": "black"},
+        qlim=False,
     )
 
     with pytest.warns(
@@ -1634,8 +1646,10 @@ def test_week9():
     res = p_kurve + p_flade + p_felt_rot
     N = r.diff(u).cross(r.diff(v))
     assert simplify(N) == Matrix([0, -u, u])
-    p_normalvektor = dtuplot.quiver(s.subs(u, 0), N.subs({u: 1, v: 0}), show=False)
-    p_omloebs = dtuplot.quiver(s.subs(u, 0), ds.subs(u, 0), show=False)
+    # Added qlim argument here to avoid warning. However, this does not
+    # affect the demos, as this is not in the demos (currently)
+    p_normalvektor = dtuplot.quiver(s.subs(u, 0), N.subs({u: 1, v: 0}), show=False, qlim=False)
+    p_omloebs = dtuplot.quiver(s.subs(u, 0), ds.subs(u, 0), show=False, qlim=False)
     p_kurve.camera = {"elev": 5, "azim": -35}
     res = p_kurve + p_flade + p_normalvektor + p_omloebs
     integrand = N.dot(dtutools.rot(V, var=[x, y, z]))
@@ -1670,11 +1684,14 @@ def test_week9():
     # sikrer os at vi gennemløber randen i den rigtige retning
     N = r.diff(u).cross(r.diff(v))
     # vektor dobbelt så lang, så den kan ses fra denne vinkel
+    # Added qlim argument here to avoid warning. However, this does not
+    # affect the demos, as this is not in the demos (currently)
     p_normalvektor = dtuplot.quiver(
         r.subs({u: 0, v: -pi / 4}),
         2 * N.subs({u: 0, v: -pi / 4}),
         {"color": "black"},
         show=False,
+        qlim=False
     )
     combined_flade = p_flade + p_felt_flade + p_normalvektor
     combined_flade.title = "Fladen og feltet"
@@ -1744,11 +1761,15 @@ def test_week9():
     )
     # for hver af de 4 felter vil vi også gerne have retningen af deres afledte
     # dette skal bruges til at bestemme hvilken retning vi skal omløbe linjerne i
+    
+    # Added qlim argument here to avoid warning. However, this does not
+    # affect the demos, as this is not in the demos (currently)
     p_omloebs = dtuplot.quiver(
         s1.subs({u: -pi / 2, v: -pi}),
         ds1.subs({u: -pi / 2, v: -pi}),
         {"color": "red"},
         show=False,
+        qlim=False,
     )
     p_omloebs.extend(
         dtuplot.quiver(
@@ -1756,6 +1777,7 @@ def test_week9():
             ds2.subs({u: -pi / 2, v: -pi}),
             {"color": "green"},
             show=False,
+            qlim=False,
         )
     )
     p_omloebs.extend(
@@ -1764,6 +1786,7 @@ def test_week9():
             ds3.subs({u: -pi / 2, v: -pi}),
             {"color": "blue"},
             show=False,
+            qlim=False,
         )
     )
     p_omloebs.extend(
@@ -1772,6 +1795,7 @@ def test_week9():
             ds4.subs({u: -pi / 2, v: -pi}),
             {"color": "purple"},
             show=False,
+            qlim=False,
         )
     )
     combined_rand = p_rand + p_flade_mesh + p_felt + p_omloebs

--- a/tests/test_F_demos.py
+++ b/tests/test_F_demos.py
@@ -28,6 +28,18 @@ def test_week1():
 
     f = 4 - x**2 - y**2
     p = dtuplot.plot3d(f, (x, -3, 3), (y, -3, 3), show=False)
+    p = dtuplot.plot3d(
+        f, (x, -3, 3), (y, -3, 3), camera={"elev": 25, "azim": 45}, show=False
+    )
+    p = dtuplot.plot3d(
+        f,
+        (x, -3, 3),
+        (y, -3, 3),
+        wireframe=True,
+        rendering_kw={"color": "red", "alpha": 0.5},
+        show=False,
+    )
+    p = dtuplot.plot3d(f, (x, -3, 3), (y, -3, 3), use_cm=True, legend=True, show=False)
 
     dtuplot.plot_contour(f, (x, -3, 3), (y, -3, 3), is_filled=False, show=False)
 
@@ -44,6 +56,15 @@ def test_week1():
     p = dtuplot.plot3d(f, (x, -3, 3), (y, -3, 3), use_cm=True, legend=True, show=False)
 
     f = cos(x) + sin(y)
+    p = dtuplot.plot3d(
+        f,
+        (x, -pi / 2, 3 / 2 * pi),
+        (y, 0, 2 * pi),
+        use_cm=True,
+        camera={"elev": 45, "azim": -65},
+        legend=True,
+        show=False,
+    )
     nf = Matrix([f.diff(x), f.diff(y)])
 
     dtuplot.plot_vector(
@@ -429,16 +450,7 @@ def test_week2():
     P6_p2 = P6.subs([(x, 1 / 2), (y, 1 / 2)])
     res = f_p2 - P1_p2, f_p2 - P2_p2, f_p2 - P6_p2
     z = symbols("z")
-    f = (
-        7 * x**2
-        - 4 * x * y
-        + 6 * y**2
-        - 4 * y * z
-        + 5 * z**2
-        - 2 * x
-        + 20 * y
-        - 10 * z
-    )
+    f = 7 * x**2 - 4 * x * y + 6 * y**2 - 4 * y * z + 5 * z**2 - 2 * x + 20 * y - 10 * z
     H = dtutools.hessian(f)
     var_vec = Matrix([x, y, z])
     A = S(1) / 2 * H
@@ -529,6 +541,7 @@ def test_week3():
     assert (0, 2) in sols
     assert (2, 0) in sols
     assert (2, 2) in sols
+    H = dtutools.hessian(f)
     fxx = f.diff(x, 2)
     fxy = f.diff(x, y)
     fyy = f.diff(y, 2)
@@ -544,16 +557,17 @@ def test_week3():
         (x, -0.8, 2.8),
         (y, -0.8, 2.8),
         use_cm=True,
+        colorbar=False,
         show=False,
         wireframe=True,
         rendering_kw={"alpha": 0.6},
     )
-    # Following command changed, as the scatter function changed. 
+    # Following command changed, as the scatter function changed.
     # Each point is now given in a list, so '*' is removed.
     points = dtuplot.scatter(
         [Matrix([x0, y0, f.subs([(x, x0), (y, y0)])]) for (x0, y0) in sols],
         show=False,
-        rendering_kw={"s": 100, "color": "red"}
+        rendering_kw={"s": 100, "color": "red"},
     )
     pf.camera = {"azim": -50, "elev": 30}
     pf.extend(points)
@@ -587,12 +601,13 @@ def test_week3():
         show=False,
         rendering_kw={"alpha": 0.5},
     )
-    # Following command changed, as the scatter function changed. 
+    pf.camera = {"azim": -161, "elev": 5}
+    # Following command changed, as the scatter function changed.
     # Each point is now given in a list, so '*' is removed.
     points = dtuplot.scatter(
         [Matrix([x0, y0, f.subs([(x, x0), (y, y0)])]) for x0, y0 in stat_punkter],
         show=False,
-        rendering_kw={"color": "red", "s": 30}
+        rendering_kw={"color": "red", "s": 30},
     )
     pf.camera = {"azim": -161, "elev": -5}
     res = pf + points
@@ -625,9 +640,16 @@ def test_week3():
     lign2 = Eq(f.diff(y), 0)
     sols = nonlinsolve([lign1, lign2], [x, y])
     assert (S(1) / 2, 0) in sols
-    dtuplot.plot(f.subs(y, -1), (x, 0, 2), show=False)
-    dtuplot.plot(f.subs(y, 1 - x), (x, 0, 2), show=False)
-    dtuplot.plot(f.subs(x, 0), (y, -1, 1), ylim=(0, 3), aspect="equal", show=False)
+    dtuplot.plot(f.subs(y, -1), (x, 0, 2), title="Randlinjen f(x, -1)", show=False)
+    dtuplot.plot(f.subs(y, 1 - x), (x, 0, 2), title="Randlinjen f(x, 1-x)", show=False)
+    dtuplot.plot(
+        f.subs(x, 0),
+        (y, -1, 1),
+        ylim=(0, 3),
+        aspect="equal",
+        title="Randlinjen f(0, y)",
+        show=False,
+    )
     stat_punkter = set(sols)
 
     lodret = solve(f.subs(x, 0).diff(y))
@@ -652,11 +674,10 @@ def test_week3():
     pf = dtuplot.plot3d(
         f, (x, 0, 2), (y, -1, 1), show=False, rendering_kw={"alpha": 0.7}
     )
-    # Following command changed, as the scatter function changed. 
+    # Following command changed, as the scatter function changed.
     # Each point is now given in a list, so '[]' is added.
     punkter = dtuplot.scatter(
-        [Matrix([2, -1, 0]),
-        Matrix([1 / 2, 0, 13 / 4])],
+        [Matrix([2, -1, 0]), Matrix([1 / 2, 0, 13 / 4])],
         show=False,
         rendering_kw={"color": "red", "s": 20},
     )
@@ -920,7 +941,7 @@ def test_week5():
         (y, -2, 2),
         use_cm=True,
         camera={"elev": 30, "azim": -130},
-        show=False
+        show=False,
     )
     kvadrat = dtuplot.plot3d_parametric_surface(
         x, y, 0, (x, -2, 2), (y, -2, 2), rendering_kw={"color": "black"}, show=False
@@ -949,7 +970,7 @@ def test_week5():
         (v, 0, 2 * pi),
         camera={"azim": -90, "elev": 15},
         title="Omdrejningsfladen",
-        show=False
+        show=False,
     )
     dtuplot.plot(
         (x - 1) ** 3 + 1, (x, 0, 2), axis_center="auto", ylabel="z", show=False
@@ -963,7 +984,7 @@ def test_week5():
         camera={"azim": -65, "elev": 25},
         use_cm=True,
         legend=False,
-        show=False
+        show=False,
     )
     profil = Matrix([2 + sin(u), 0, u])
     dtuplot.plot3d_parametric_line(
@@ -971,7 +992,7 @@ def test_week5():
         (u, 0, 8 * pi),
         use_cm=False,
         camera={"azim": -28, "elev": 13},
-        show=False
+        show=False,
     )
     r = Matrix([(2 + sin(u)) * cos(v), (2 + sin(u)) * sin(v), u])
     flade = dtuplot.plot3d_parametric_surface(
@@ -981,7 +1002,7 @@ def test_week5():
         camera={"azim": -62, "elev": 15},
         use_cm=True,
         legend=False,
-        show=False
+        show=False,
     )
     lede = Matrix([2 * cos(u), sin(u), 0])
     dtuplot.plot3d_parametric_line(
@@ -997,7 +1018,7 @@ def test_week5():
         zlim=(0, 2),
         use_cm=True,
         legend=False,
-        show=False
+        show=False,
     )
     r = Matrix([2 * cos(u), sin(u), v * (2 * cos(u) + sin(u) ** 2)])
     dtuplot.plot3d_parametric_surface(
@@ -1007,7 +1028,7 @@ def test_week5():
         camera={"azim": -120, "elev": 20},
         use_cm=True,
         legend=False,
-        show=False
+        show=False,
     )
     h = x**2 / 2 + y + 2
     with pytest.warns(
@@ -1031,7 +1052,7 @@ def test_week5():
         v_range,
         show=False,
         rendering_kw={"color": "blue"},
-        camera={"azim": -155, "elev": 15}
+        camera={"azim": -155, "elev": 15},
     )
     grundflade = dtuplot.plot3d_parametric_surface(
         r[0], r[1], 0, u_range, v_range, show=False, rendering_kw={"alpha": 0.6}
@@ -1339,9 +1360,7 @@ def test_week7():
     divV0 = divV.subs([(x, 1), (y, 2), (z, 3)])
     N(divV0)
     rotV = dtutools.rot(V, var=[x, y, z])
-    assert rotV == Matrix(
-        [-x * z**3, x * y * cos(z) + y * z**3, -x * sin(z) + log(y)]
-    )
+    assert rotV == Matrix([-x * z**3, x * y * cos(z) + y * z**3, -x * sin(z) + log(y)])
     assert dtutools.rot(V2, var=[u, v, w]) == Matrix([-2 * w, -sin(w), 0])
     rotV0 = rotV.subs([(x, 1), (y, 2), (z, 3)])
     N(rotV0)
@@ -1358,7 +1377,7 @@ def test_week8():
         (v, -pi, pi),
         use_cm=False,
         camera={"elev": 25, "azim": -55},
-        show=False
+        show=False,
     )
     p_felt = dtuplot.plot_vector(
         V,
@@ -1409,7 +1428,7 @@ def test_week8():
         n1=4,
         n2=16,
         camera={"elev": 25, "azim": -55},
-        show=False
+        show=False,
     )
     p_feltlåg = dtuplot.plot_vector(
         V,
@@ -1580,7 +1599,7 @@ def test_week9():
         zlim=(-1.1, 1.1),
         use_cm=False,
         aspect="equal",
-        show=False
+        show=False,
     )
     p_felt = dtuplot.plot_vector(
         V,
@@ -1632,7 +1651,7 @@ def test_week9():
         use_cm=False,
         aspect="equal",
         camera={"elev": 30, "azim": -80},
-        show=False
+        show=False,
     )
     dummy_surface = dtuplot.plot3d_parametric_surface(
         *r, (u, -pi / 2, pi / 2), (v, -pi, pi / 2), n=10, show=False
@@ -1674,7 +1693,7 @@ def test_week9():
         use_cm=False,
         aspect="equal",
         camera={"elev": 30, "azim": -80},
-        show=False
+        show=False,
     )
     p_rand.extend(
         dtuplot.plot3d_parametric_line(
@@ -1682,7 +1701,7 @@ def test_week9():
             (v, -pi, pi / 2),
             {"color": "orange", "linewidth": 5},
             use_cm=False,
-            show=False
+            show=False,
         )
     )
     p_rand.extend(
@@ -1691,7 +1710,7 @@ def test_week9():
             (u, -pi / 2, pi / 2),
             {"color": "orange", "linewidth": 5},
             use_cm=False,
-            show=False
+            show=False,
         )
     )
     p_rand.extend(
@@ -1700,7 +1719,7 @@ def test_week9():
             (u, -pi / 2, pi / 2),
             {"color": "orange", "linewidth": 5},
             use_cm=False,
-            show=False
+            show=False,
         )
     )
     p_flade_mesh = dtuplot.plot3d_parametric_surface(
@@ -1710,7 +1729,7 @@ def test_week9():
         rendering_kw={"alpha": 0},
         wf_rendering_kw={"alpha": 0.4},
         wireframe=True,
-        show=False
+        show=False,
     )
     p_felt = dtuplot.plot_vector(
         V,

--- a/tests/test_dtuplot.py
+++ b/tests/test_dtuplot.py
@@ -643,7 +643,3 @@ def test_scatterplot():
         AssertionError, match="Length of all points in list must match!"
     ):
         dtuplot.scatter([[1, 2, 3], [1, 2]], backend=dtuplot.MB, show=False)
-
-
-if __name__ == "__main__":
-    test_quiver()

--- a/tests/test_dtuplot.py
+++ b/tests/test_dtuplot.py
@@ -11,7 +11,8 @@ del test
 
 # Disable mayavi tests for github actions, as this fails
 # Reactivate when support for mayavi should return for 4.8.2
-test_mab = False
+test_mab = True
+
 
 def test_quiver():
     # matplotlib
@@ -88,7 +89,11 @@ def test_quiver():
             # from mayavi import mlab  # used for the mayavi test to disable popups
             # mlab.options.offscreen = True
             dtuplot.quiver(
-                Matrix([1, 2, 3]), Matrix([4, 5, 6]), backend=MAB, show=False, warning=False
+                Matrix([1, 2, 3]),
+                Matrix([4, 5, 6]),
+                backend=MAB,
+                show=False,
+                warning=False,
             )
             dtuplot.quiver([1, 2, 3], [4, 5, 6], backend=MAB, show=False, warning=False)
             dtuplot.quiver(1, 2, 0, 0, 0, 3, backend=MAB, show=False, warning=False)
@@ -126,16 +131,12 @@ def test_quiver():
                 warning=False,
             )
             dtuplot.quiver(
-                [1, 2, 3],
-                [4, 5, 6],
-                backend=MAB,
-                qlim=False,
-                show=False,
-                warning=False
+                [1, 2, 3], [4, 5, 6], backend=MAB, qlim=False, show=False, warning=False
             )
 
         with pytest.raises(
-            NotImplementedError, match="Mayavi backend does not support 2D vector plots!"
+            NotImplementedError,
+            match="Mayavi backend does not support 2D vector plots!",
         ):
             dtuplot.quiver([1, 2], [4, 5], backend=MAB, show=False, warning=False)
 
@@ -542,7 +543,11 @@ def test_scatterplot():
                 show=False,
             )
             dtuplot.scatter(
-                np.array([1, 2, 3]), Matrix([4, 5, 6]), [7, 8, 9], backend=MAB, show=False
+                np.array([1, 2, 3]),
+                Matrix([4, 5, 6]),
+                [7, 8, 9],
+                backend=MAB,
+                show=False,
             )
             dtuplot.scatter(Matrix([-1, 0, 1]), backend=MAB, show=False)
             dtuplot.scatter(Matrix([0, 0, 0]), backend=MAB, show=False)
@@ -553,7 +558,9 @@ def test_scatterplot():
             dtuplot.scatter([[1, 2, 3], [4, 5, 6]], backend=MAB, show=False)
             dtuplot.scatter([(1, 2, 3), [4, 5, 6]], backend=MAB, show=False)
             dtuplot.scatter([Matrix([1, 2, 3]), [4, 5, 6]], backend=MAB, show=False)
-            dtuplot.scatter([Matrix([1, 2, 3]), Matrix([4, 5, 6])], backend=MAB, show=False)
+            dtuplot.scatter(
+                [Matrix([1, 2, 3]), Matrix([4, 5, 6])], backend=MAB, show=False
+            )
             dtuplot.scatter([np.array([1, 2, 3]), [4, 5, 6]], backend=MAB, show=False)
             dtuplot.scatter(
                 [np.array([1, 2, 3]), np.array([4, 5, 6])], backend=MAB, show=False
@@ -633,3 +640,7 @@ def test_scatterplot():
         AssertionError, match="Length of all points in list must match!"
     ):
         dtuplot.scatter([[1, 2, 3], [1, 2]], backend=dtuplot.MB, show=False)
+
+
+if __name__ == "__main__":
+    test_quiver()

--- a/tests/test_dtuplot.py
+++ b/tests/test_dtuplot.py
@@ -20,25 +20,25 @@ test_mab = False
 def test_quiver():
     # matplotlib
     dtuplot.quiver(
-        Matrix([1, 2, 3]), Matrix([4, 5, 6]), {"color": "red"}, backend=MB, show=False
+        Matrix([1, 2, 3]), Matrix([4, 5, 6]), {"color": "red"}, backend=MB, show=False, qlim=True,
     )
-    dtuplot.quiver([1, 2, 3], [4, 5, 6], backend=MB, show=False)
+    dtuplot.quiver([1, 2, 3], [4, 5, 6], backend=MB, show=False, qlim=True)
     dtuplot.quiver([1, 2], [4, 5], backend=MB, show=False)
     dtuplot.quiver(Matrix([1, 2]), Matrix([4, 5]), backend=MB, show=False)
     dtuplot.quiver(
-        1, 2, 0, 0, 0, 3, rendering_kw={"color": "orange"}, backend=MB, show=False
+        1, 2, 0, 0, 0, 3, rendering_kw={"color": "orange"}, backend=MB, show=False, xlim=[0,10], ylim=[-5,5], zlim=[-5,5],
     )
     dtuplot.quiver(1, 2, 1, 2, backend=MB, show=False)
     dtuplot.quiver((1, 2), (1, 2), backend=MB, show=False)
     dtuplot.quiver(np.array([1, 2]), (1, 2), backend=MB, show=False)
     dtuplot.quiver(np.array([1, 2]), np.array([1, 2]), backend=MB, show=False)
     dtuplot.quiver(np.array([1, 2]), Matrix([1, 2]), backend=MB, show=False)
-    dtuplot.quiver(np.array([1, 2, 3]), (1, 2, 3), backend=MB, show=False)
-    dtuplot.quiver(np.array([1, 2, 3]), np.array([1, 2, 3]), backend=MB, show=False)
-    dtuplot.quiver(np.array([1, 2, 3]), Matrix([1, 2, 3]), backend=MB, show=False)
-    dtuplot.quiver([1, 2, 3], Matrix([1, 2, 3]), label="123", backend=MB, show=False)
-    dtuplot.quiver([1, 2, 3], Matrix([1, 2, 3]), label=["123"], backend=MB, show=False)
-    dtuplot.quiver([1, 2, 3], [4, 5, 6], backend=MB, qlim=False, show=False)
+    dtuplot.quiver(np.array([1, 2, 3]), (1, 2, 3), backend=MB, show=False, qlim=True)
+    dtuplot.quiver(np.array([1, 2, 3]), np.array([1, 2, 3]), backend=MB, show=False, qlim=True)
+    dtuplot.quiver(np.array([1, 2, 3]), Matrix([1, 2, 3]), backend=MB, show=False, qlim=True)
+    dtuplot.quiver([1, 2, 3], Matrix([1, 2, 3]), label="123", backend=MB, show=False, qlim=True)
+    dtuplot.quiver([1, 2, 3], Matrix([1, 2, 3]), label=["123"], backend=MB, show=False, qlim=True)
+    dtuplot.quiver([1, 2, 3], [4, 5, 6], backend=MB, qlim=False, show=False, xlim=[0,10], ylim=[-5,5], zlim=[-5,5])
     dtuplot.quiver([1, 2], [4, 5], backend=MB, qlim=False, show=False)
     # plotly
     dtuplot.quiver(Matrix([1, 2, 3]), Matrix([4, 5, 6]), show=False, backend=PB)
@@ -230,6 +230,12 @@ def test_quiver():
         NotImplementedError, match="Interactive quiver plots are not yet implemented!"
     ):
         dtuplot.quiver([1, 2, 3], Matrix([1, 2, 3]), params=123, backend=MB, show=False)
+    
+    with pytest.warns(
+            UserWarning,
+            match="Warning: Limits were not given for a 3D quiver using Matplotlib. ",
+        ):
+        dtuplot.quiver([1, 2, 3], [1, 2, 3], backend=MB, show=False)
 
 
 def test_boundary():

--- a/tests/test_dtuplot.py
+++ b/tests/test_dtuplot.py
@@ -10,8 +10,11 @@ test = 0
 del test
 
 # Disable mayavi tests for github actions, as this fails
-# Reactivate when support for mayavi should return for 4.8.2
-test_mab = True
+# Updating mayavi to 4.8.2 has solved many problems for windows and
+# macos users, but requires additional packages for linux
+# before pytest works. Reactivate if mayavi is to be better supported
+# in the future...
+test_mab = False
 
 
 def test_quiver():


### PR DESCRIPTION
This is a **draft PR**. 

(Planned) Changes are listed here:

- [x] Update matplotlib to new version (currently testing 3.9).
- [x] Limit numpy to less than 2.0.
- [x] Update supported Python versions to 3.9-3.12.
- [x] Update Mayavi version to 4.8.2, allowing for (potential) use of this backend. **Update**: Too many problems occurred, so I removed the mayavi support. Known problems before we can integrate this: 1. No binary wheel installation through pip. 2. Additional installs required for ubuntu (popouts etc), making the install (and workflow tests) more difficult.
- [x] Update CI to use "--only-binary", such that workflow only looks for wheels.
- [x] Add additional tests that check for the "use_cm" flag (which can fail for some spb+matplotlib version interactions).
- [x] Update to new major spb version (version 3.x.x). This will also fix current issue where the `use_cm=True` kwarg fails in *spb==2.4.3*.
- [x] Update 2D/3D vector plotting to use (new) major spb version functionality
- [ ] (Optional) Change tests, such that different backends are not in the same test (and non-used backends are not tested by default).
- [x] Fix "*(core dumped) pytest*" error on workflow for Ubuntu.
- [x] Add periodic workflow such that we catch potential errors before they reach students.
- [x] Flexibility in terms of labels. Labels can now be given as both *kwargs* and in the *rendering_kw* dictionary. Additionally, latex code should automatically be detected (if written as `"$xyz_{abc}$"`) and written simply as a string (eg. `"xyz_{abc}"`).

When testing for the success of this update, few errors/mistakes etc have been found in the demos. Also, the changes caused by this update can affect some demos. The known things that need to be changed in the demos after this update (before the semester) are:

- [ ] E11: `lamb = symbols('\lambda')` causes *SyntaxWarning: invalid escape sequence '\l'*
- [ ] E11: `K(3).nullspace()` causes *TypeError: 'MutableDenseMatrix' object is not callable*
- [ ] (Suggestion) F_intro & F1: Few instances of `plot(...)` (directly calling function from `sympy`) instead of `dtuplot.plot(...)`. I suggest staying consistent and staying in `dtuplot`.
- [ ] F1: Instructions to download this package as `pip install dtumathtools`. This should be updated to reflect the backend and version (for instance `pip install dtumathtools[qt]==2024.2`)
- [ ] F2: Currently `p.xlim` and `p.ylim` are given. This is discussed [here](https://github.com/dtudk/dtumathtools/issues/26) and the previous solution is given [here](https://github.com/dtudk/dtumathtools/pull/27). However, the new quiver updates has solved this problem. Therefore, we do not need the limits at all here!
- [ ] F6 and F8: Some of the `dtuplot.plot_implicit(...)` functions give a *warning*. Can be worked around by setting the kwarg `adaptive=True`.
- [ ] F7: We are asking the students to install `numpy` (which is already done in dtumathtools) and `scipy`! Should we add `scipy` as a requirement to avoid having this as part of a demo?